### PR TITLE
Setup TypeORM migrations with .env configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli",
-    "migration:generate": "npm run typeorm -- migration:generate -d ./typeorm.config.ts",
+    "migration:generate": "npm run typeorm -- migration:generate ./src/migrations/InitialMigration -d ./typeorm.config.ts",
     "migration:run": "npm run typeorm -- migration:run -d ./typeorm.config.ts",
     "migration:revert": "npm run typeorm -- migration:revert -d ./typeorm.config.ts"
   },

--- a/src/migrations/1759166001569-InitialMigration.ts
+++ b/src/migrations/1759166001569-InitialMigration.ts
@@ -1,0 +1,158 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class InitialMigration1759166001569 implements MigrationInterface {
+  name = 'InitialMigration1759166001569';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE \`users\` (\`id\` int NOT NULL AUTO_INCREMENT, \`full_name\` varchar(255) NOT NULL, \`username\` varchar(255) NOT NULL, \`phone\` varchar(255) NOT NULL, \`email\` varchar(255) NOT NULL, \`hashed_password\` varchar(255) NOT NULL, \`user_type\` enum ('admin', 'customer', 'chef', 'driver') NOT NULL, \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), UNIQUE INDEX \`IDX_fe0bb3f6520ee0469504521e71\` (\`username\`), UNIQUE INDEX \`IDX_97672ac88f789774dd47f7c8be\` (\`email\`), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE \`orders\` (\`id\` int NOT NULL AUTO_INCREMENT, \`order_number\` int NOT NULL, \`total_price\` decimal NOT NULL, \`payment_method\` varchar(255) NOT NULL, \`order_type\` enum ('delivery', 'pickup', 'dine_in') NOT NULL, \`delivery_location\` text NULL, \`status\` enum ('pending', 'confirmed', 'preparing', 'out_for_delivery', 'completed', 'cancelled') NOT NULL, \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`user_id\` int NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE \`reviews\` (\`id\` int NOT NULL AUTO_INCREMENT, \`rating\` int NOT NULL, \`comment\` text NULL, \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`user_id\` int NULL, \`order_id\` int NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE \`categories\` (\`id\` int NOT NULL AUTO_INCREMENT, \`name\` varchar(255) NOT NULL, \`description\` varchar(255) NULL, \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE \`menu\` (\`id\` int NOT NULL AUTO_INCREMENT, \`item_name\` varchar(255) NOT NULL, \`price\` decimal NOT NULL, \`description\` text NULL, \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`category_id\` int NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE \`order_items\` (\`id\` int NOT NULL AUTO_INCREMENT, \`quantity\` int NOT NULL, \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`order_id\` int NULL, \`item_id\` int NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE \`prepared_orders\` (\`id\` int NOT NULL AUTO_INCREMENT, \`status\` enum ('not_ready', 'ready') NOT NULL, \`prepared_at\` timestamp NULL, \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`order_item_id\` int NULL, \`prepared_by\` int NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE \`inventory\` (\`id\` int NOT NULL AUTO_INCREMENT, \`item_name\` varchar(255) NOT NULL, \`quantity\` int NOT NULL, \`unit\` varchar(255) NOT NULL, \`reorder_level\` int NOT NULL, \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`managed_by\` int NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE \`drivers\` (\`id\` int NOT NULL AUTO_INCREMENT, \`vehicle_number\` varchar(255) NOT NULL, \`license_number\` varchar(255) NOT NULL, \`hire_date\` date NOT NULL, \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`user_id\` int NULL, UNIQUE INDEX \`REL_8e224f1b8f05ace7cfc7c76d03\` (\`user_id\`), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE \`deliveries\` (\`id\` int NOT NULL AUTO_INCREMENT, \`delivery_fee\` decimal NOT NULL, \`status\` enum ('assigned', 'in_progress', 'delivered') NOT NULL, \`picked_up_at\` timestamp NULL, \`delivered_at\` timestamp NULL, \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`order_id\` int NULL, \`driver_id\` int NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE \`customers\` (\`id\` int NOT NULL AUTO_INCREMENT, \`address\` text NOT NULL, \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`user_id\` int NULL, UNIQUE INDEX \`REL_11d81cd7be87b6f8865b0cf766\` (\`user_id\`), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE \`chefs\` (\`id\` int NOT NULL AUTO_INCREMENT, \`specialty\` varchar(255) NOT NULL, \`hire_date\` date NOT NULL, \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`user_id\` int NULL, UNIQUE INDEX \`REL_12b483f03241f2bf43c8a74f5c\` (\`user_id\`), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`orders\` ADD CONSTRAINT \`FK_a922b820eeef29ac1c6800e826a\` FOREIGN KEY (\`user_id\`) REFERENCES \`users\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`reviews\` ADD CONSTRAINT \`FK_728447781a30bc3fcfe5c2f1cdf\` FOREIGN KEY (\`user_id\`) REFERENCES \`users\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`reviews\` ADD CONSTRAINT \`FK_e4b0ed40bdd0f318108612c2851\` FOREIGN KEY (\`order_id\`) REFERENCES \`orders\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`menu\` ADD CONSTRAINT \`FK_246dfbfa0f3b0a4e953f7490544\` FOREIGN KEY (\`category_id\`) REFERENCES \`categories\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`order_items\` ADD CONSTRAINT \`FK_145532db85752b29c57d2b7b1f1\` FOREIGN KEY (\`order_id\`) REFERENCES \`orders\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`order_items\` ADD CONSTRAINT \`FK_de591fd3dc04191ab115c03eab1\` FOREIGN KEY (\`item_id\`) REFERENCES \`menu\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`prepared_orders\` ADD CONSTRAINT \`FK_5e64dbd77a216482322194bd72a\` FOREIGN KEY (\`order_item_id\`) REFERENCES \`order_items\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`prepared_orders\` ADD CONSTRAINT \`FK_33aa141b567552b88213f3d13f7\` FOREIGN KEY (\`prepared_by\`) REFERENCES \`users\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`inventory\` ADD CONSTRAINT \`FK_45f8d3a77a8660251fb5339a9fd\` FOREIGN KEY (\`managed_by\`) REFERENCES \`users\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`drivers\` ADD CONSTRAINT \`FK_8e224f1b8f05ace7cfc7c76d03b\` FOREIGN KEY (\`user_id\`) REFERENCES \`users\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`deliveries\` ADD CONSTRAINT \`FK_789dba7900f6d25550280ad3b93\` FOREIGN KEY (\`order_id\`) REFERENCES \`orders\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`deliveries\` ADD CONSTRAINT \`FK_0bb1b190c636bee8f5cafd239ef\` FOREIGN KEY (\`driver_id\`) REFERENCES \`users\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`customers\` ADD CONSTRAINT \`FK_11d81cd7be87b6f8865b0cf7661\` FOREIGN KEY (\`user_id\`) REFERENCES \`users\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`chefs\` ADD CONSTRAINT \`FK_12b483f03241f2bf43c8a74f5c1\` FOREIGN KEY (\`user_id\`) REFERENCES \`users\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`chefs\` DROP FOREIGN KEY \`FK_12b483f03241f2bf43c8a74f5c1\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`customers\` DROP FOREIGN KEY \`FK_11d81cd7be87b6f8865b0cf7661\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`deliveries\` DROP FOREIGN KEY \`FK_0bb1b190c636bee8f5cafd239ef\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`deliveries\` DROP FOREIGN KEY \`FK_789dba7900f6d25550280ad3b93\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`drivers\` DROP FOREIGN KEY \`FK_8e224f1b8f05ace7cfc7c76d03b\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`inventory\` DROP FOREIGN KEY \`FK_45f8d3a77a8660251fb5339a9fd\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`prepared_orders\` DROP FOREIGN KEY \`FK_33aa141b567552b88213f3d13f7\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`prepared_orders\` DROP FOREIGN KEY \`FK_5e64dbd77a216482322194bd72a\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`order_items\` DROP FOREIGN KEY \`FK_de591fd3dc04191ab115c03eab1\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`order_items\` DROP FOREIGN KEY \`FK_145532db85752b29c57d2b7b1f1\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`menu\` DROP FOREIGN KEY \`FK_246dfbfa0f3b0a4e953f7490544\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`reviews\` DROP FOREIGN KEY \`FK_e4b0ed40bdd0f318108612c2851\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`reviews\` DROP FOREIGN KEY \`FK_728447781a30bc3fcfe5c2f1cdf\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`orders\` DROP FOREIGN KEY \`FK_a922b820eeef29ac1c6800e826a\``,
+    );
+    await queryRunner.query(
+      `DROP INDEX \`REL_12b483f03241f2bf43c8a74f5c\` ON \`chefs\``,
+    );
+    await queryRunner.query(`DROP TABLE \`chefs\``);
+    await queryRunner.query(
+      `DROP INDEX \`REL_11d81cd7be87b6f8865b0cf766\` ON \`customers\``,
+    );
+    await queryRunner.query(`DROP TABLE \`customers\``);
+    await queryRunner.query(`DROP TABLE \`deliveries\``);
+    await queryRunner.query(
+      `DROP INDEX \`REL_8e224f1b8f05ace7cfc7c76d03\` ON \`drivers\``,
+    );
+    await queryRunner.query(`DROP TABLE \`drivers\``);
+    await queryRunner.query(`DROP TABLE \`inventory\``);
+    await queryRunner.query(`DROP TABLE \`prepared_orders\``);
+    await queryRunner.query(`DROP TABLE \`order_items\``);
+    await queryRunner.query(`DROP TABLE \`menu\``);
+    await queryRunner.query(`DROP TABLE \`categories\``);
+    await queryRunner.query(`DROP TABLE \`reviews\``);
+    await queryRunner.query(`DROP TABLE \`orders\``);
+    await queryRunner.query(
+      `DROP INDEX \`IDX_97672ac88f789774dd47f7c8be\` ON \`users\``,
+    );
+    await queryRunner.query(
+      `DROP INDEX \`IDX_fe0bb3f6520ee0469504521e71\` ON \`users\``,
+    );
+    await queryRunner.query(`DROP TABLE \`users\``);
+  }
+}


### PR DESCRIPTION
This PR implements TypeORM migrations for the restaurant-api project and ensures the database configuration is centralized in the .env file.

Changes include:
    Added typeorm.config.ts to load DB credentials from .env for migrations.
    Updated package.json scripts for:
        Generating migrations
        Running migrations
        Reverting migrations
    Added a sample Category entity to test migration workflow.
    Verified that migrations can be generated, applied, and reverted successfully. Also tested with postman and  was able to sent a post requests and it was a success
